### PR TITLE
feat: added problem, try, and either utilities

### DIFF
--- a/src/main/kotlin/dev/dfreer/contacts/utilities/Either.kt
+++ b/src/main/kotlin/dev/dfreer/contacts/utilities/Either.kt
@@ -1,0 +1,10 @@
+package dev.dfreer.contacts.utilities
+
+sealed interface Either<LEFT, RIGHT>
+data class Left<LEFT, RIGHT>(val value: LEFT) : Either<LEFT, RIGHT>
+data class Right<LEFT, RIGHT>(val value: RIGHT) : Either<LEFT, RIGHT>
+
+fun <T> Try<T>.toEither(): Either<Problem, T> = when (this) {
+    is Success -> Right(value)
+    is Failure -> Left(problem)
+}

--- a/src/main/kotlin/dev/dfreer/contacts/utilities/Problem.kt
+++ b/src/main/kotlin/dev/dfreer/contacts/utilities/Problem.kt
@@ -1,0 +1,3 @@
+package dev.dfreer.contacts.utilities
+
+data class Problem(val message: String?, val exception: Exception?)

--- a/src/main/kotlin/dev/dfreer/contacts/utilities/Try.kt
+++ b/src/main/kotlin/dev/dfreer/contacts/utilities/Try.kt
@@ -1,0 +1,14 @@
+package dev.dfreer.contacts.utilities
+
+sealed interface Try<T>
+data class Success<T>(val value: T) : Try<T>
+data class Failure<T>(val problem: Problem) : Try<T>
+
+inline fun <T> tryDoing(
+    message: String? = null,
+    something: () -> T
+): Try<T> = try {
+    Success(something())
+} catch (e: Exception) {
+    Failure(Problem(message, e))
+}

--- a/src/test/kotlin/dev/dfreer/contacts/utilities/EitherTest.kt
+++ b/src/test/kotlin/dev/dfreer/contacts/utilities/EitherTest.kt
@@ -1,0 +1,20 @@
+package dev.dfreer.contacts.utilities
+
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class EitherTest {
+    @Test
+    fun `given a successful try, should return a right`() {
+        assertIs<Right<Problem, Something>>(
+            Success(Something).toEither()
+        )
+    }
+
+    @Test
+    fun `given a failed try, should return a left`() {
+        assertIs<Left<Problem, Something>>(
+            Failure<Something>(Problem(null, null)).toEither()
+        )
+    }
+}

--- a/src/test/kotlin/dev/dfreer/contacts/utilities/Something.kt
+++ b/src/test/kotlin/dev/dfreer/contacts/utilities/Something.kt
@@ -1,0 +1,3 @@
+package dev.dfreer.contacts.utilities
+
+internal typealias Something = Unit

--- a/src/test/kotlin/dev/dfreer/contacts/utilities/TryTest.kt
+++ b/src/test/kotlin/dev/dfreer/contacts/utilities/TryTest.kt
@@ -1,0 +1,20 @@
+package dev.dfreer.contacts.utilities
+
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class TryTest {
+    @Test
+    fun `when trying to do something succeeds, should return a success`() {
+        assertIs<Success<Something>>(
+            tryDoing { Something }
+        )
+    }
+
+    @Test
+    fun `when trying to do something fails, should return a failure`() {
+        assertIs<Failure<Something>>(
+            tryDoing { throw IllegalStateException("Failed to do something") }
+        )
+    }
+}


### PR DESCRIPTION
At some point we will want to be able to handle problems and exceptions
with our code.

The Problem class is useful for reporting what went wrong, whether
that's a simple message or an actual exception.

The Try interface is similar to Optional, but allows for wrapping a
try/catch and returning a Problem if an exception occurs.

The Either interface allows for methods to return two things from a
method instead of just one. Normal kotlin convention is that when a
method returns, it either returns a type, a nullable type, or
throws an exception. Now we can return Either<Problem, T> which
could contain the type, or a reportable Problem.